### PR TITLE
Urgent bug fixes for issue: https://github.com/bcgov/identity-kit-poc/issues/62

### DIFF
--- a/identity-controller/src/app/admin/connections/connection.controller.ts
+++ b/identity-controller/src/app/admin/connections/connection.controller.ts
@@ -1,7 +1,7 @@
 import * as Router from 'koa-router';
 import { Context } from 'koa';
 import { Connection } from '../../../core/agent-controller/modules/connection/connection.model';
-import base64url from 'base64url'
+import base64url from 'base64url';
 
 const apiUrl = process.env.AGENT_ADMIN_URL;
 
@@ -10,21 +10,21 @@ console.log('api Url', apiUrl);
 const connection = new Connection(apiUrl || '');
 
 const routerOpts = {
-  prefix: '/connections'
+  prefix: '/connections',
 };
 
 const router = new Router(routerOpts);
- 
+
 router.get('/', async (ctx: Context) => {
   try {
     const invite = await connection.createInvitation();
-    const baseInvite = base64url(JSON.stringify(invite.invitation))
+    const baseInvite = base64url(JSON.stringify(invite.invitation));
     invite.base = baseInvite;
     if (!invite) return ctx.throw(404);
     return (ctx.body = invite);
   } catch (err) {
     console.log(err.message);
-    return ctx.throw(500);
+    return ctx.throw(500, 'no invite created. Check agent status');
   }
 });
 

--- a/identity-controller/src/app/admin/invitation/invitation.controller.ts
+++ b/identity-controller/src/app/admin/invitation/invitation.controller.ts
@@ -168,6 +168,18 @@ router.post('/:id/revoke/', async (ctx: Context) => {
     id,
   });
   ctx.body = res;
+  const mail = await emailSvc.mailInvite({
+    address: res.email,
+    url: `${publicUrl}validate?invite_token=${res.linkId}`,
+  });
+  if (!mail) {
+    console.log('email failed to send', res.email);
+
+    ctx.throw(
+      500,
+      `${res.email} was added to the POC. They did not receive an e-mail invitation due to an internal server error.`,
+    );
+  }
 });
 
 router.get('/:id', async (ctx: Context) => {

--- a/identity-controller/src/app/admin/issues/issue.controller.ts
+++ b/identity-controller/src/app/admin/issues/issue.controller.ts
@@ -14,7 +14,7 @@ export interface ICredentialPayload {
 
 export interface ICredentialClaims {
   userdisplayname: string;
-  emailaddress: string;
+  address: string;
   surname: string;
   givenname: string;
   birthdate: string;
@@ -24,6 +24,7 @@ export interface ICredentialClaims {
   stateorprovince: string;
   postalcode: string;
   country: string;
+  issued: string;
 }
 
 const routerOpts = {
@@ -35,6 +36,7 @@ const router = new Router(routerOpts);
 router.post('/', async (ctx: Context) => {
   const { _id, ...data } = (ctx.request.body = ctx.request
     .body as ICredentialPayload);
+  data.claims.issued = new Date().toUTCString();
 
   const keys = Object.keys(data.claims);
   const claims = data.claims as any;
@@ -48,10 +50,10 @@ router.post('/', async (ctx: Context) => {
       setTimeout(resolve, ms);
     });
   }
-  console.log('start break');
+  // console.log('start break');
 
-  await wait(5000);
-  console.log('end break');
+  // await wait(5000);
+  // console.log('end break');
   try {
     const res = await issueSvc.issueCredential({
       connId: data.connectionId,

--- a/identity-controller/src/app/admin/issues/issue.service.ts
+++ b/identity-controller/src/app/admin/issues/issue.service.ts
@@ -46,6 +46,7 @@ export class IssueService {
     attrs: ICredentialAttributes[];
   }) {
     const { connId, attrs } = args;
+
     try {
       const res = await this._issue.issueOfferSend(
         connId,

--- a/identity-controller/src/app/admin/issues/schema.ts
+++ b/identity-controller/src/app/admin/issues/schema.ts
@@ -15,7 +15,7 @@ const attributes = [
 const schemaDef = {
   attributes,
   schema_name: 'verified_person',
-  schema_version: '1.23',
+  schema_version: '1.22',
 };
 
 export default schemaDef;

--- a/identity-controller/src/app/admin/issues/schema.ts
+++ b/identity-controller/src/app/admin/issues/schema.ts
@@ -1,6 +1,6 @@
 const attributes = [
   'userdisplayname',
-  'emailaddress',
+  'email',
   'surname',
   'givenname',
   'birthdate',
@@ -8,13 +8,14 @@ const attributes = [
   'locality',
   'stateorprovince',
   'postalcode',
-  'country'
+  'country',
+  'issued',
 ];
 
 const schemaDef = {
   attributes,
   schema_name: 'verified_person',
-  schema_version: '1.2'
+  schema_version: '1.23',
 };
 
 export default schemaDef;

--- a/identity-controller/src/app/admin/webhooks/webhooks.controller.ts
+++ b/identity-controller/src/app/admin/webhooks/webhooks.controller.ts
@@ -2,6 +2,7 @@ import * as Router from 'koa-router';
 import { Context } from 'koa';
 import { ICredHookResponse } from '../../../core/interfaces/cred-hook-response.interface';
 import { client } from '../../../index';
+import { Connection } from '../../../core/agent-controller/modules/connection/connection.model';
 
 export interface IConnectionActivity {
   created_at: string;
@@ -25,8 +26,18 @@ const routerOpts = {
 
 const router = new Router(routerOpts);
 
+const connCtrl = new Connection(
+  process.env.AGENT_ADMIN_URL || 'http://localhost:8024/',
+);
+
 router.post('/connections', async (ctx: Context) => {
   const data = ctx.request.body as IConnectionActivity;
+  const { state, connection_id: connectionId } = data;
+  if (state === 'response') {
+    console.log('connections response', data);
+    connCtrl.requestResponse(connectionId);
+    connCtrl.sendTrustPing(connectionId);
+  }
   return (ctx.status = 200);
 });
 

--- a/identity-controller/src/app/services/email.service.ts
+++ b/identity-controller/src/app/services/email.service.ts
@@ -2,8 +2,11 @@ import * as nodemailer from 'nodemailer';
 import Mail = require('nodemailer/lib/mailer');
 import { emailTemplate } from './invitation_email';
 
+const adminEmail = process.env.ADMIN_EMAIL;
+
 export class EmailService {
   transporter: Mail;
+  adminEmail: string | undefined;
   constructor(opts: {
     host: string;
     port: number;
@@ -21,6 +24,7 @@ export class EmailService {
       logger: true,
     });
     this.transporter = transport;
+    this.adminEmail = adminEmail;
   }
 
   async mailInvite(opts: { address: string; url: string }) {
@@ -30,7 +34,8 @@ export class EmailService {
         from: 'Identity Kit POC <no-reply@gov.bc.ca>',
         to: address,
         subject: 'Welcome to the Identity Kit POC test.',
-        html: emailTemplate(url),
+        // TODO: @SH - change this to an env variable
+        html: emailTemplate(url, 'peter.Watkins@gov.bc.ca'),
       });
       return mail;
     } catch (err) {

--- a/identity-controller/src/app/services/invitation_email.ts
+++ b/identity-controller/src/app/services/invitation_email.ts
@@ -1,8 +1,7 @@
-export const emailTemplate = (url: string) => { 
-  
+export const emailTemplate = (url: string, adminAddress: string) => {
   return `<p>
 You have received this invitation from name@email.com. If you have any
-questions please contact them by sending an email to <a href="mailto:name@email.com">name@email.com</a>. 
+questions please contact them by sending an email to <a href="mailto:${adminAddress}">${adminAddress}</a>. 
 </p>
 <p>
 This proof of concept is facilitated by the Digital ID and Authentication
@@ -48,12 +47,12 @@ Please install one of the following:
 Step 2: Obtain your proof of concept digital ID for verified person
 </p>
 <p>
-Use the following link <a href="${url}">Link</a>
+Use the following <a href="${url}">Link</a>
 </p>
 <p>
 You can use this link multiple times to allow for demonstrations you may want to
 do. If you find that the link has expired, please request a new invitation by
-sending an email to <a href="mailto:name@email.com">name@email.com</a>. 
+sending an email to <a href="mailto:${adminAddress}">${adminAddress}</a>. 
 </p>
 <p>
 Step 3: Use your proof of concept digital ID at proof of concept demonstration services. 
@@ -89,4 +88,5 @@ diam. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
 cubilia Curae; Morbi lacinia molestie dui. Praesent blandit dolor. Sed non quam.
 In vel mi sit amet augue congue elementum. Morbi in ipsum sit amet pede
 facilisis laoreet. Donec lacus nunc, viverra nec.
-</p>`}
+</p>`;
+};

--- a/wa-admin/src/app/pages/home/components/add-user/add-user.component.ts
+++ b/wa-admin/src/app/pages/home/components/add-user/add-user.component.ts
@@ -8,7 +8,7 @@ import { IInvitationRecord } from 'src/app/shared/interfaces/invitation-record.i
 import { AlertService } from 'src/app/services/alert.service';
 import { Router } from '@angular/router';
 
-const url = environment.publicUrl;
+const url = 'https://identity-kit.pathfinder.gov.bc.ca/';
 
 @Component({
   selector: 'waa-add-user',

--- a/wa-admin/src/app/pages/home/components/view/view.component.ts
+++ b/wa-admin/src/app/pages/home/components/view/view.component.ts
@@ -25,7 +25,7 @@ export interface IFields {
   value: string;
 }
 
-const publicUrl = environment.publicUrl;
+const publicUrl = 'https://identity-kit.pathfinder.gov.bc.ca/';
 
 @Component({
   selector: 'waa-view',

--- a/wa-admin/src/environments/environment.ts
+++ b/wa-admin/src/environments/environment.ts
@@ -5,7 +5,7 @@
 export const environment = {
   production: false,
   apiUrl: 'http://localhost:5000/',
-  publicUrl: 'http://localhost:4251/'
+  publicUrl: 'https://identity-kit.pathfinder.gov.bc.ca/'
 };
 
 /*

--- a/wa-public/src/app/components/accept-disclaimer/accept-disclaimer.component.ts
+++ b/wa-public/src/app/components/accept-disclaimer/accept-disclaimer.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
+import { Router, ActivatedRoute } from '@angular/router';
+import { StateService } from 'src/app/services/state.service';
+import { ActionService } from 'src/app/services/action.service';
 
 @Component({
   selector: 'wap-accept-disclaimer',
@@ -9,7 +11,7 @@ import { Router } from '@angular/router';
         <ion-title>Accept Terms</ion-title>
       </ion-toolbar>
     </ion-header>
-    <wap-view-wrapper>
+    <wap-view-wrapper *ngIf="hasId; else noIdHelper">
       <mat-card>
         <mat-card-content>
           <ion-item lines="none">
@@ -36,14 +38,39 @@ import { Router } from '@angular/router';
         </mat-card-actions>
       </mat-card>
     </wap-view-wrapper>
+    <ng-template #noIdHelper>
+    <wap-view-wrapper>
+      <mat-card>
+      <mat-card-title>
+       Please re-enter invitation link.
+      </mat-card-title>
+      <mat-card-content>
+        Your session has expired. Please re-enter the link from the POC Invitation email.
+      </mat-card-content>
+      </mat-card>
+    </wap-view-wrapper>
+  </ng-template>
   `,
   styleUrls: ['./accept-disclaimer.component.scss']
 })
 export class AcceptDisclaimerComponent implements OnInit {
+  hasId = true;
   accepted = false;
-  constructor(private router: Router) {}
+  constructor(private router: Router, private stateSvc: StateService, private route: ActivatedRoute) {}
 
-  ngOnInit() {}
+  async ngOnInit() {
+    const token = this.route.snapshot.paramMap.get('id')
+
+    if (!this.stateSvc._id) {
+      try {
+      const res = await this.stateSvc.isValidToken(token)
+      res._id ? this.stateSvc._id = res._id : this.hasId = false
+      } catch {
+        this.hasId = false;
+      }
+
+    }
+  }
   submit() {
     this.router.navigate(['/success']);
   }

--- a/wa-public/src/app/pages/success/success.component.ts
+++ b/wa-public/src/app/pages/success/success.component.ts
@@ -485,6 +485,7 @@ export class SuccessComponent implements OnInit, OnDestroy {
     return map;
   }
   fakeConnection() {
+    if (!this.stateSvc._id) return this.hasId = false;
     const form = this.fg.getRawValue();
     const timer = interval(7000);
     this.subs.push(

--- a/wa-public/src/app/pages/success/success.component.ts
+++ b/wa-public/src/app/pages/success/success.component.ts
@@ -503,7 +503,7 @@ export class SuccessComponent implements OnInit, OnDestroy {
                   userdisplayname: `${form.firstName} ${form.lastName}`,
                   stateorprovince: 'BC',
                   locality: form.locality,
-                  emailaddress: form.emailAddress,
+                  email: form.emailAddress,
                   birthdate: form.dateOfBirth,
                   surname: form.lastName,
                   givenname: form.firstName,

--- a/wa-public/src/app/pages/success/success.component.ts
+++ b/wa-public/src/app/pages/success/success.component.ts
@@ -28,7 +28,7 @@ import { encodeBase64 } from './encode.script';
         </ion-buttons>
       </ion-toolbar>
     </ion-header>
-    <wap-view-wrapper>
+    <wap-view-wrapper *ngIf="hasId; else noIdHelper">
       <ion-grid *ngIf="index === 0">
         <ion-row>
           <ion-col>
@@ -250,12 +250,25 @@ import { encodeBase64 } from './encode.script';
         </mat-card>
       </mat-card>
     </wap-view-wrapper>
+    <ng-template #noIdHelper>
+      <wap-view-wrapper>
+        <mat-card>
+        <mat-card-title>
+         Please re-enter invitation link.
+        </mat-card-title>
+        <mat-card-content>
+          Your session has expired. Please re-enter the link from the POC Invitation email.
+        </mat-card-content>
+        </mat-card>
+      </wap-view-wrapper>
+    </ng-template>
   `,
   styleUrls: ['./success.component.scss']
 })
 export class SuccessComponent implements OnInit, OnDestroy {
   accepted = false;
   connectionId: string;
+  hasId = true;
   get formInvalid() {
     return !this.accepted || this.fg.invalid;
   }
@@ -371,6 +384,7 @@ export class SuccessComponent implements OnInit, OnDestroy {
   ) {}
 
   async ngOnInit() {
+    if (!this.stateSvc._id) return this.hasId = false;
     const user = this.stateSvc.user;
     const keys = Object.keys(user);
     this.disableList = keys.filter(

--- a/wa-public/src/app/services/action.service.ts
+++ b/wa-public/src/app/services/action.service.ts
@@ -40,7 +40,7 @@ export interface IssueCredential {
 }
 export interface Claims {
   userdisplayname: string;
-  emailaddress: string;
+  email: string;
   surname: string;
   givenname: string;
   birthdate: string;


### PR DESCRIPTION
Added webhook response to send a trust ping and send a request response when the connection is in response status.
Schema version now contains issued field. Also contains the changed emailaddress to email field. Schema version bumped to 1.22
Front end now handles path when the _id is lost. (will do a quick change later tonight to store the _id and guid values into local storage)
Emails will now re-send from the admin controls.
Fixed links for the admin panel
Updated email text to include peter.watkins@gov.bc.ca as the recipient for forwarding issues.