### PR TITLE
Fix final problem for Issue: https://github.com/bcgov/identity-kit-poc/issues/62

### DIFF
--- a/identity-controller/src/app/admin/issues/issue.controller.ts
+++ b/identity-controller/src/app/admin/issues/issue.controller.ts
@@ -50,10 +50,10 @@ router.post('/', async (ctx: Context) => {
       setTimeout(resolve, ms);
     });
   }
-  // console.log('start break');
+  console.log('start break');
 
-  // await wait(5000);
-  // console.log('end break');
+  await wait(5000);
+  console.log('end break');
   try {
     const res = await issueSvc.issueCredential({
       connId: data.connectionId,
@@ -70,10 +70,11 @@ router.post('/', async (ctx: Context) => {
       query: {
         connectionId: data.connectionId,
         credExId: res.credential_exchange_id,
+        issued: false,
+        consumed: true,
       },
       id: _id,
     });
-    console.log('record result', record);
     ctx.body = res;
   } catch (err) {
     ctx.throw(500, 'failed to create credential exchange record');

--- a/identity-controller/src/app/admin/webhooks/webhooks.controller.ts
+++ b/identity-controller/src/app/admin/webhooks/webhooks.controller.ts
@@ -38,7 +38,6 @@ router.post('/connections', async (ctx: Context) => {
   const data = ctx.request.body as IConnectionActivity;
   const { state, connection_id: connectionId } = data;
   if (state === 'response') {
-    console.log('connections response', data);
     connCtrl.requestResponse(connectionId);
     connCtrl.sendTrustPing(connectionId);
   }
@@ -48,8 +47,8 @@ router.post('/connections', async (ctx: Context) => {
 router.post('/issue_credential', async (ctx: Context) => {
   const data = ctx.request.body as ICredHookResponse;
   console.log(data);
-  if (data.state === 'response_received') {
-    console.log('Credential has been store', data.credential_exchange_id);
+  if (data.state === 'request_received') {
+    console.info('Credential has been requested', data.credential_exchange_id);
     const res = await client.getRecordByQuery({
       collection: 'invitations',
       query: { credExId: data.credential_exchange_id },
@@ -75,6 +74,7 @@ router.post('/issue_credential', async (ctx: Context) => {
   if (data.state === 'issued') {
     console.log('Credential has been issued', data.credential_exchange_id);
   }
+  /*
   if (data.state === 'stored') {
     console.log('Credential has been store', data.credential_exchange_id);
     const res = await client.getRecordByQuery({
@@ -98,6 +98,7 @@ router.post('/issue_credential', async (ctx: Context) => {
         data.credential_exchange_id,
       );
   }
+  */
   return (ctx.status = 200);
 });
 

--- a/identity-controller/src/core/agent-controller/modules/issue/issue.model.ts
+++ b/identity-controller/src/core/agent-controller/modules/issue/issue.model.ts
@@ -107,24 +107,7 @@ export class Issue {
       throw new Error(err.message);
     }
   }
-  /*
-    This does not work correctly as a result of what appears to be an AcaPy bug.
 
-    {
-  "credential_preview": {
-    "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/credential-preview",
-    "attributes": [
-      {
-        "name": "favourite_drink",
-        "mime-type": "image/jpeg",
-        "value": "martini"
-      }
-    ]
-  },
-  "connection_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-  "comment": "string",
-  "credential_definition_id": "WgWxqztrNooG92RXvxSTWv:3:CL:20:tag"
-  */
 
   async issueAndSendCred(
     connId: string,


### PR DESCRIPTION
This fix is intended to resolve the "flow" problem of issuing a credential. The app would not always wait for a credential to be accepted.
Adjusted status to wait for request_received for the issue_credential webhook controller in order for the app to display the correct status.
Adjusted app so that when a new credential is requested by the same user they will have status reset to consumed rather than issued.

