### PR TITLE
Frontend/public bugfixes and enhancements related to https://github.com/bcgov/identity-kit-poc/issues/78 

### DIFF
--- a/identity-controller/src/app/admin/invitation/invitation.controller.ts
+++ b/identity-controller/src/app/admin/invitation/invitation.controller.ts
@@ -50,6 +50,7 @@ router.get('/', async (ctx: Context) => {
     clearTimeout(timer);
   }
 });
+
 router.post('/', async (ctx: Context) => {
   const data = ctx.request.body;
   if (!data) return ctx.throw(400, 'no data to add');

--- a/identity-controller/src/app/admin/invitation/invitation.service.ts
+++ b/identity-controller/src/app/admin/invitation/invitation.service.ts
@@ -9,7 +9,7 @@ export interface IValidateLink {
 }
 
 export class InvitationService {
-  constructor() {
+  constructor () {
     // this._client.connect();
   }
 
@@ -22,6 +22,7 @@ export class InvitationService {
       query: { linkId },
     });
     if (!res) return { _id: '', active: false, expired: true };
+    if (res.issued) return { _id: res._id, active: true, expired: false, email: res.email }
     return {
       _id: res._id,
       active: res.active,

--- a/identity-controller/src/app/admin/invitation/invitation.service.ts
+++ b/identity-controller/src/app/admin/invitation/invitation.service.ts
@@ -5,6 +5,7 @@ export interface IValidateLink {
   _id: string;
   expired: boolean;
   active: boolean;
+  email?: string;
 }
 
 export class InvitationService {
@@ -25,6 +26,7 @@ export class InvitationService {
       _id: res._id,
       active: res.active,
       expired: res.expiry.getTime() <= Date.now(),
+      email: res.email
     };
   }
 

--- a/identity-controller/src/app/admin/issues/issue.controller.ts
+++ b/identity-controller/src/app/admin/issues/issue.controller.ts
@@ -1,6 +1,6 @@
 import * as Router from 'koa-router';
 import { Context } from 'koa';
-import { IssueService } from './issue.service';
+import { IssueService, futureDate } from './issue.service';
 import { client } from '../../../index';
 
 const apiUrl = process.env.AGENT_ADMIN_URL;
@@ -65,9 +65,11 @@ router.post('/', async (ctx: Context) => {
       );
       return ctx.throw(500, 'failed to create credential exchange record');
     }
+    const expiry = futureDate(710);
     const record = await client.updateRecord({
       collection: 'invitations',
       query: {
+        expiry,
         connectionId: data.connectionId,
         credExId: res.credential_exchange_id,
         issued: false,

--- a/identity-controller/src/app/admin/issues/issue.service.ts
+++ b/identity-controller/src/app/admin/issues/issue.service.ts
@@ -61,6 +61,10 @@ export class IssueService {
   }
 }
 
-export function futureDate(year: number = 2099) {
-  return new Date(year)
+export function futureDate(offset: number = 99) {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = today.getMonth();
+  const day = today.getDate();
+  return new Date(year + offset, month, day)
 }

--- a/identity-controller/src/app/admin/issues/issue.service.ts
+++ b/identity-controller/src/app/admin/issues/issue.service.ts
@@ -13,7 +13,7 @@ export class IssueService {
 
   apiUrl: string;
 
-  constructor(apiUrl: string) {
+  constructor (apiUrl: string) {
     console.log(apiUrl);
     this.apiUrl = apiUrl;
     const schema = new Schema(apiUrl);
@@ -59,4 +59,8 @@ export class IssueService {
       console.log('issue credential error', err);
     }
   }
+}
+
+export function futureDate(year: number = 2099) {
+  return new Date(year)
 }

--- a/wa-admin/package.json
+++ b/wa-admin/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "start-docker": "npm install && ng serve --host 0.0.0.0 --port 4250 --poll 2000",
+    "start-docker": "npm install && ng serve --host 0.0.0.0 --port 4250 --poll 2000 --disable-host-check",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",

--- a/wa-admin/src/app/pages/home/components/user-list-item/user-list-item.component.ts
+++ b/wa-admin/src/app/pages/home/components/user-list-item/user-list-item.component.ts
@@ -10,7 +10,6 @@ import { Router } from '@angular/router';
     <mat-card class="mat-elevation-z0">
       <ion-item>
         <mat-checkbox
-          *ngIf="!consumed"
           color="accent"
           [(ngModel)]="invitationRecord.changed"
           (change)="activeChange(_id)"

--- a/wa-admin/src/app/pages/home/components/view/view.component.scss
+++ b/wa-admin/src/app/pages/home/components/view/view.component.scss
@@ -1,3 +1,14 @@
 ion-badge {
   font-weight: lighter;
 }
+@media (min-width: 800px) {
+  mat-card, waa-card-toolbar {
+    max-width: 700px;
+  }
+}
+
+@media (min-width: 1000px) {
+  mat-card, waa-card-toolbar {
+    max-width: 900px;
+  }
+}

--- a/wa-admin/src/app/pages/home/components/view/view.component.ts
+++ b/wa-admin/src/app/pages/home/components/view/view.component.ts
@@ -154,7 +154,9 @@ export class ViewComponent implements OnInit {
       map(obs => {
         const accessLabel = obs.active ? 'Revoke Access' : 'Grant Access';
         return obs.consumed
-          ? []
+          ? [
+            { label: 'Send Email', key: 'email' }
+          ]
           : [
               { label: 'Send Email', key: 'email' },
               { label: accessLabel, key: 'revoke' }

--- a/wa-admin/src/app/pages/home/home.page.ts
+++ b/wa-admin/src/app/pages/home/home.page.ts
@@ -36,7 +36,7 @@ import { StateService } from 'src/app/services/state.service';
               <mat-icon slot="icon-only">person_add</mat-icon>
             </ion-button>
           </ion-buttons>
-          <ion-buttons slot="primary" *ngIf="stateSvc.state === 'invited'">
+          <ion-buttons slot="primary">
             <ion-button slot="start" [matMenuTriggerFor]="menu">
               <mat-icon slot="icon-only">more_vert</mat-icon>
             </ion-button>
@@ -49,7 +49,6 @@ import { StateService } from 'src/app/services/state.service';
 
     <mat-menu #menu="matMenu">
       <button
-        *ngIf="stateSvc.state === 'invited'"
         mat-menu-item
         (click)="changeAction('email')"
         [disabled]="stateSvc.changeRecords.size < 1"

--- a/wa-admin/src/app/services/action.service.ts
+++ b/wa-admin/src/app/services/action.service.ts
@@ -83,7 +83,9 @@ export class ActionService {
           addedBy: this.stateSvc.user.username
         })
         .toPromise();
+
     }
+
   }
   async sendEmail(records: string[] | string) {
     if (Array.isArray(records)) {
@@ -107,7 +109,9 @@ export class ActionService {
           addedBy: this.stateSvc.user.username
         })
         .toPromise();
+
     }
+
   }
 
   changeAccess(records: string[]) {

--- a/wa-admin/src/app/shared/components/card-toolbar/card-toolbar.component.scss
+++ b/wa-admin/src/app/shared/components/card-toolbar/card-toolbar.component.scss
@@ -1,0 +1,12 @@
+@media (min-width: 800px) {
+  ion-toolbar {
+    max-width: 700px;
+  }
+}
+
+@media (min-width: 1000px) {
+  ion-toolbar {
+    max-width: 900px;
+  }
+}
+

--- a/wa-public/package.json
+++ b/wa-public/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --port=4251",
-    "start-docker": "npm install && ng serve --host 0.0.0.0 --port 4251 --poll 2000",
+    "start-docker": "npm install && ng serve --host 0.0.0.0 --port 4251 --poll 2000 --disable-host-check",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",

--- a/wa-public/src/app/app-routing.module.ts
+++ b/wa-public/src/app/app-routing.module.ts
@@ -8,6 +8,7 @@ import { SuccessComponent } from './pages/success/success.component';
 import { TrackComponent } from './pages/track/track.component';
 import { AcceptDisclaimerComponent } from './components/accept-disclaimer/accept-disclaimer.component';
 import { RequestTokenComponent } from './components/request-token/request-token.component';
+import { CompletedComponent } from './pages/completed/completed.component';
 
 const routes: Routes = [
   {
@@ -36,6 +37,10 @@ const routes: Routes = [
   {
     path: 'request/:id',
     component: RequestTokenComponent,
+  },
+  {
+    path: 'completed',
+    component: CompletedComponent
   },
   { path: '**', component: PageNotFoundComponent },
 ];

--- a/wa-public/src/app/app.module.ts
+++ b/wa-public/src/app/app.module.ts
@@ -33,6 +33,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatInputModule } from '@angular/material/input';
 import { MatNativeDateModule } from '@angular/material/core';
+import { CompletedComponent } from './pages/completed/completed.component';
 
 const keycloakService = new KeycloakService();
 
@@ -65,10 +66,11 @@ const components = [
   TrackComponent,
   RequestTokenComponent,
   AcceptDisclaimerComponent,
+  CompletedComponent
 ];
 
 @NgModule({
-  declarations: [AppComponent, [...components]],
+  declarations: [[...components], AppComponent],
   imports: [
     BrowserModule,
     AppRoutingModule,
@@ -105,7 +107,7 @@ export class AppModule {
             checkLoginIframe: false,
           },
           // `/^\/validate\?invite_token=*([^\n\r]*)/gim`
-          bearerExcludedUrls: ['/assets', '/validate', '/accept', '/renew', '/request'],
+          bearerExcludedUrls: ['/assets', '/validate', '/accept', '/renew', '/request', '/completed', '/logout'],
         })
         .then(() => {
           console.log('[ngDoBootstrap] bootstrap app');

--- a/wa-public/src/app/components/credential-issuance/credential-issuance.component.ts
+++ b/wa-public/src/app/components/credential-issuance/credential-issuance.component.ts
@@ -6,6 +6,7 @@ import { interval } from 'rxjs/internal/observable/interval';
 import { StateService } from 'src/app/services/state.service';
 import { Observable, of, Subscription } from 'rxjs';
 import { ActionService } from 'src/app/services/action.service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'wap-credential-issuance',
@@ -107,9 +108,7 @@ export class CredentialIssuanceComponent implements OnInit, OnDestroy {
     }
   };
 
-  constructor(private http: HttpClient, private stateSvc: StateService, private actionSvc: ActionService) {}
-
-  private transactionStateURL: string;
+  constructor(private router: Router, private stateSvc: StateService, private actionSvc: ActionService) {}
 
   ngOnInit() {
      // TODO @SH: set the current connection id
@@ -121,19 +120,26 @@ export class CredentialIssuanceComponent implements OnInit, OnDestroy {
         switchMap(() => this.actionSvc.getCredentialById(this.credExId)) // TODO: @SH replace with this.transactionStateURL
       )
       .subscribe(res => {
-        console.log(res)
-        if (!res) return
-        this.updateProgress(res.issued)
+        console.log(res);
+        if (!res) return;
+        if (this.step === 3) return this.completeProgress();
+
+        this.updateProgress(res.issued);
       }));
     // setTimeout(() => (this.step = 3), 20000);
     const user = this.stateSvc.user;
     if (user) this.$user = of(`${user.firstName}`);
   }
   ngOnDestroy() {
-    this.subs.forEach(sub => sub.unsubscribe())
+    this.subs.forEach(sub => sub.unsubscribe());
   }
 
   updateProgress(issued: boolean) {
     if (issued) this.step = 3;
+  }
+
+  async completeProgress() {
+    await this.actionSvc.logout('https://identity-kit.pathfinder.gov.bc/completed');
+    // this.router.navigate(['/completed']);
   }
 }

--- a/wa-public/src/app/components/request-token/request-token.component.ts
+++ b/wa-public/src/app/components/request-token/request-token.component.ts
@@ -19,8 +19,9 @@ import { LoadingController } from '@ionic/angular';
           <img mat-card-avatar src="assets/VON-Logo.png" alt="VON Network logo" class="header-image" />
           <mat-card-title>Request Token</mat-card-title>
           <mat-card-subtitle
-            >Your token has expired. To continue using the Identity Kit Proof of Concept please request a new token
-            below.</mat-card-subtitle
+            >Your token has expired. To continue using the Identity Kit Proof of Concept(POC) please request a new token
+            below. We've entered the email address that was originally signed up for the POC. If you'd like to use a
+            different address to receive your new invite please enter it here.</mat-card-subtitle
           >
         </mat-card-header>
 
@@ -63,8 +64,10 @@ export class RequestTokenComponent implements OnInit {
     private actionSvc: ActionService,
     private route: ActivatedRoute,
     private loadingCtrl: LoadingController,
+    private stateSvc: StateService,
   ) {
-    const fc = new FormControl('', [Validators.required, Validators.email]);
+    const email = this.stateSvc.email || '';
+    const fc = new FormControl(email, [Validators.required, Validators.email]);
     this.fc = fc;
   }
 

--- a/wa-public/src/app/guards/valid-invite.guard.ts
+++ b/wa-public/src/app/guards/valid-invite.guard.ts
@@ -2,13 +2,18 @@ import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, RouterStateSnapshot, UrlTree, Router } from '@angular/router';
 import { Observable } from 'rxjs';
 import { StateService } from '../services/state.service';
-import { map } from 'rxjs/operators';
+import { map, tap } from 'rxjs/operators';
+import { ActionService } from '../services/action.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ValidInviteGuard implements CanActivate {
-  constructor(private stateService: StateService, private router: Router) {}
+  constructor (
+    private stateService: StateService,
+    private router: Router,
+    private actionSvc: ActionService
+  ) { }
 
   canActivate(
     route: ActivatedRouteSnapshot,
@@ -17,11 +22,12 @@ export class ValidInviteGuard implements CanActivate {
     const inviteToken = route.queryParamMap.get('invite_token');
 
     return this.stateService.isValidToken(inviteToken).pipe(
+      tap(obs => this.actionSvc.email = obs.email || ''),
       map(obs => {
         console.log(obs);
         if (!obs) return false;
         if (!obs.active) return this.router.createUrlTree(['/']);
-        if (obs.active && obs.expired) return this.router.createUrlTree([`request/${inviteToken}`]);
+        if (obs.active && obs.expired) return this.router.createUrlTree([`request/${inviteToken}`])
         return this.router.createUrlTree([`accept/${inviteToken}`]);
       }),
     );

--- a/wa-public/src/app/pages/completed/completed.component.scss
+++ b/wa-public/src/app/pages/completed/completed.component.scss
@@ -1,0 +1,11 @@
+.header-image {
+  border-radius: 0;
+  width: 60px;
+  height: 60px;
+}
+
+@media (min-width: 660px) {
+  mat-card {
+    max-width: 660px;
+  }
+}

--- a/wa-public/src/app/pages/completed/completed.component.spec.ts
+++ b/wa-public/src/app/pages/completed/completed.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CompletedComponent } from './completed.component';
+
+describe('CompletedComponent', () => {
+  let component: CompletedComponent;
+  let fixture: ComponentFixture<CompletedComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ CompletedComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CompletedComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/wa-public/src/app/pages/completed/completed.component.ts
+++ b/wa-public/src/app/pages/completed/completed.component.ts
@@ -1,0 +1,42 @@
+import { Component, OnInit } from '@angular/core';
+import { of } from 'rxjs';
+import { StateService } from 'src/app/services/state.service';
+
+@Component({
+  selector: 'wap-completed',
+  template: `
+  <ion-header *ngIf="$title | async as title">
+  <ion-toolbar color="primary">
+    <ion-title> {{ title }}</ion-title>
+
+  </ion-toolbar>
+</ion-header>
+<wap-view-wrapper>
+  <mat-card>
+    <mat-card-header>
+    <img mat-card-avatar src="assets/VON-Logo.png" alt="VON Network logo" class="header-image" />
+      <mat-card-title>
+        Congratulations on issuing a credential!
+      </mat-card-title>
+      <mat-card-subtitle>
+        We have logged you out of the demo and marked it as completed. 
+        To issue yourself another credential please go <a [href]="pocLink">here.</a>
+      </mat-card-subtitle>
+    </mat-card-header>
+  </mat-card>
+</wap-view-wrapper>
+  `,
+  styleUrls: ['./completed.component.scss']
+})
+export class CompletedComponent implements OnInit {
+  $title = of('Identity Kit POC')
+  pocLink: string;
+
+  constructor(private stateSvc: StateService) { 
+    this.pocLink = `validate?invite_token=${this.stateSvc.linkId}`
+  }
+
+  ngOnInit() {
+  }
+
+}

--- a/wa-public/src/app/pages/success/success.component.ts
+++ b/wa-public/src/app/pages/success/success.component.ts
@@ -15,7 +15,7 @@ import { take, mergeMap } from 'rxjs/operators';
         <ion-title> {{ title }}</ion-title>
 
         <ion-buttons slot="primary">
-          <ion-button (click)="actionSvc.logout()">
+          <ion-button (click)="logout()">
             <ion-label>Logout</ion-label>
             <ion-icon name="log-out"></ion-icon>
           </ion-button>
@@ -393,7 +393,6 @@ export class SuccessComponent implements OnInit, OnDestroy {
     this.invite = invitation.invitation as any;
     this.img = `https://chart.googleapis.com/chart?cht=qr&chs=300x300&chld=L|0&chl=${encoded}`;
     this.deeplink = `id.streetcred://launch?d_m=${invitation.base}`;
-    console.log(this.deeplink);
     const previewData = of(this.setPreview(this.fg));
     this.$previewData = previewData;
     this.setIndex(0);
@@ -482,5 +481,8 @@ export class SuccessComponent implements OnInit, OnDestroy {
           }
         }),
     );
+  }
+  async logout() {
+    await this.actionSvc.logout()
   }
 }

--- a/wa-public/src/app/pages/success/success.component.ts
+++ b/wa-public/src/app/pages/success/success.component.ts
@@ -392,7 +392,7 @@ export class SuccessComponent implements OnInit, OnDestroy {
     console.log(encoded);
     this.invite = invitation.invitation as any;
     this.img = `https://chart.googleapis.com/chart?cht=qr&chs=300x300&chld=L|0&chl=${encoded}`;
-    this.deeplink = `id.streetcred://launch?c_i=${invitation.invitation}`;
+    this.deeplink = `id.streetcred://launch?d_m=${invitation.base}`;
     console.log(this.deeplink);
     const previewData = of(this.setPreview(this.fg));
     this.$previewData = previewData;

--- a/wa-public/src/app/pages/track/track.component.ts
+++ b/wa-public/src/app/pages/track/track.component.ts
@@ -11,7 +11,7 @@ import { ActivatedRoute } from '@angular/router';
         <ion-title> {{ title }}</ion-title>
 
         <ion-buttons slot="primary">
-          <ion-button (click)="actionSvc.logout()">
+          <ion-button (click)="logout()">
             <ion-label>Logout</ion-label>
             <ion-icon name="log-out"></ion-icon>
           </ion-button>
@@ -35,5 +35,8 @@ export class TrackComponent implements OnInit {
   ngOnInit() {
     const credExId = this.route.snapshot.paramMap.get('id');
     this.$id.next(credExId);
+  }
+  async logout() {
+    await this.actionSvc.logout()
   }
 }

--- a/wa-public/src/app/services/action.service.ts
+++ b/wa-public/src/app/services/action.service.ts
@@ -113,8 +113,8 @@ export class ActionService {
     this.keyCloakSvc.loadUserProfile().then((res: Keycloak.KeycloakProfile) => (this.stateSvc.user = res));
   }
 
-  logout() {
-    this.keyCloakSvc.logout();
+  async logout(uri?: string) {
+    return this.keyCloakSvc.logout(uri || '');
   }
 
   getInvitation() {

--- a/wa-public/src/app/services/action.service.ts
+++ b/wa-public/src/app/services/action.service.ts
@@ -103,7 +103,11 @@ export class ActionService {
     // TODO: @ES some authentication logic here
   }
 
-  constructor(
+  set email(addr: string) {
+    localStorage.setItem('email', addr);
+  }
+
+  constructor (
     private keyCloakSvc: KeycloakService,
     private stateSvc: StateService,
     private http: HttpClient,

--- a/wa-public/src/app/services/state.service.ts
+++ b/wa-public/src/app/services/state.service.ts
@@ -14,6 +14,7 @@ export interface IValidateLink {
   _id: string;
   expired: boolean;
   active: boolean;
+  email?: string;
 }
 
 @Injectable({
@@ -35,6 +36,10 @@ export class StateService {
     localStorage.setItem('id', id);
   }
 
+  get email(): string {
+    return localStorage.getItem('email') || ''
+  }
+
   user: IUser = {};
   private _apiUrl: string;
 
@@ -52,7 +57,7 @@ export class StateService {
     return this._title;
   }
 
-  constructor(private http: HttpClient) {
+  constructor (private http: HttpClient) {
     this._apiUrl = apiUrl;
   }
 }

--- a/wa-public/src/app/services/state.service.ts
+++ b/wa-public/src/app/services/state.service.ts
@@ -22,7 +22,6 @@ export interface IValidateLink {
 export class StateService {
   private _isAuth = false;
   private _title = 'Identity Kit POC';
-  guid: string;
 
   get linkId() {
     return localStorage.getItem('linkId');


### PR DESCRIPTION
Changes:

1. Corrected the deeplink for opening the connection request in the streetcred app on apple devices.
2. Added a new completed component for further instructions on next steps. The text currently is pretty empty, I'll send an e-mail out with what it says and we can iterate on that. Right now it has a prompt to re-issue themselves a credential.
3. The above link will log the user out after the credential is requested.
4. Some minor corrections for viewing a record on the admin portal on desktop to prevent the card from spanning across a full page.
5. updated the validate token route to return the original email address used to sign-up the token with. This pre-pops in the email address field on the request new token page. Changed the verbiage as well to better reflect the intended user instructions. The email address is now stored in the localstorage on the browser where it can be accessed. 
6. adjusted API to always return for true if the user has previously issued themselves a credential and also set the expiry token to be indefinitely available after they issue a token for themselves
7. Added controls to re-send an e-mail for a user who has completed the issuance process but would like to receive a new link in the event they lost it. This will set the expiry to be next day as it uses the same route for re-sending an invite as the generic user does, however an issued credential state will still remain so they will be able to use the new link indefinitely. Can refine the API to allow for a flexible selection of future dates if required.

