### PR TITLE
Pipeline refactoring and optimization

### DIFF
--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -1,3 +1,3 @@
-FROM bcgovimages/aries-cloudagent:py36-1.11-1_0.3.5
+FROM bcgovimages/aries-cloudagent:py36-1.11-1_0.4.0
 
 RUN echo "Just pulling the image from Docker Hub"

--- a/jenkins/config.groovy
+++ b/jenkins/config.groovy
@@ -1,0 +1,35 @@
+// Pipeline Configuration Properties
+// Import this file into the pipeline using 'load'.
+class config {
+
+  // Wait timeout in minutes
+  public static final int WAIT_TIMEOUT = 10
+
+  // Deployment configuration
+  public static final String[] DEPLOYMENT_ENVIRONMENT_TAGS = ['dev', 'test', 'prod']
+  // public static final String DEV_ENV = "${DEPLOYMENT_ENVIRONMENT_TAGS[0]}"
+  // public static final String TEST_ENV = "${DEPLOYMENT_ENVIRONMENT_TAGS[1]}"
+  public static final String PROD_ENV = "${DEPLOYMENT_ENVIRONMENT_TAGS[2]}"
+
+  // The name of the project namespace(s).
+  public static final String  NAME_SPACE = 'devex-von'
+
+  // The application label
+  // This is used to find all of the build configurations associated to the application
+  // To work the build configurations must have an "app" label;
+  // - For example; app=identity-kit
+  public static final String APP_LABEL = 'identity-kit'
+  public static final String BASE_IMAGE_SELECTOR = "${APP_LABEL}-base-image"
+  public static final String RUNTIME_IMAGE_SELECTOR = "${APP_LABEL}-runtime"
+
+  // List of apps that will require to be deployed.
+  // Databases are not included since they will not likely change often.
+  public static final String[] APPS = ['identity-kit-admin', 'identity-kit-public', 'identity-kit-controller', 'identity-kit-agent']
+  public static final Map<String, String> APP_CONTEXT_DIRS = ['identity-kit-admin-angular':'wa-admin', 'identity-kit-admin':'wa-admin', 'identity-kit-public-angular':'wa-public', 'identity-kit-public':'wa-public', 'identity-kit-controller':'identity-controller', 'identity-kit-agent':'docker/agent']
+
+  // Build configuration
+  public static final String  APP_NAME = "${this.APPS}"
+  public static final String[] BUILDS = ["${this.APPS}"]
+}
+
+return new config();

--- a/jenkins/identity-kit/Jenkinsfile
+++ b/jenkins/identity-kit/Jenkinsfile
@@ -45,42 +45,46 @@ String getImageTagHash(OpenShiftDSL openshift, String imageName, String tag = ""
 }
 
 void build(String imageSelector) {
-  //  Retrieve all build configurations based on the selector
-  def buildConfigsAll = openshift.selector("bc", [ "app-group" : "${imageSelector}" ])
-  echo "Found ${buildConfigsAll.count()} buildconfigs for app label (app-group=${imageSelector}): ${buildConfigsAll.names()}"
+  openshift.withCluster() {
+    openshift.withProject() {
+      //  Retrieve all build configurations based on the selector
+      def buildConfigsAll = openshift.selector("bc", [ "app-group" : "${imageSelector}" ])
+      echo "Found ${buildConfigsAll.count()} buildconfigs for app label (app-group=${imageSelector}): ${buildConfigsAll.names()}"
 
-  // Set 'run-build' label based on wether there have been changes in the context directory
-  buildConfigsAll.withEach {
-    def buildName = it.name().split("/")[1];
-    def contextDir = config.APP_CONTEXT_DIRS[buildName];
-    if(triggerBuild(contextDir)){
-        setRunBuildLabel(it, 'true');
-    }
-  }
+      // Set 'run-build' label based on wether there have been changes in the context directory
+      buildConfigsAll.withEach {
+        def buildName = it.name().split("/")[1];
+        def contextDir = config.APP_CONTEXT_DIRS[buildName];
+        if(triggerBuild(contextDir)){
+            setRunBuildLabel(it, 'true');
+        }
+      }
 
-  // Retrieve all the build configs that need to be executed
-  def buildConfigsRun = openshift.selector("bc", [ "app-group" : "${imageSelector}", "run-build" : "true" ])
-  echo "Found ${buildConfigsRun.count()} buildconfigs for app label (app=${imageSelector}, run-build=true): ${buildConfigsRun.names()}"
+      // Retrieve all the build configs that need to be executed
+      def buildConfigsRun = openshift.selector("bc", [ "app-group" : "${imageSelector}", "run-build" : "true" ])
+      echo "Found ${buildConfigsRun.count()} buildconfigs for app label (app=${imageSelector}, run-build=true): ${buildConfigsRun.names()}"
 
-  // Kick off all the builds in parallel ...
-  def builds = buildConfigsRun.startBuild()
-  echo "Started ${builds.count()} builds: ${builds.names()}"
+      // Kick off all the builds in parallel ...
+      def builds = buildConfigsRun.startBuild()
+      echo "Started ${builds.count()} builds: ${builds.names()}"
 
-  // Reset run-build label now that builds have started
-  buildConfigsRun.withEach {
-      setRunBuildLabel(it, 'false');
-  }
+      // Reset run-build label now that builds have started
+      buildConfigsRun.withEach {
+          setRunBuildLabel(it, 'false');
+      }
 
-  timeout(config.WAIT_TIMEOUT) {
-    // Wait for all the builds to complete ...
-    // This section will exit after the last build completes.
-    echo "Waiting for builds to complete ..."
-    builds.withEach {
-      // untilEach and watch - do not support watching multiple named resources,
-      // so we have to feed it one at a time.
-      it.untilEach(1) {
-          echo "${it.object().status.phase} - ${it.name()}"
-          return (it.object().status.phase == "Complete")
+      timeout(config.WAIT_TIMEOUT) {
+        // Wait for all the builds to complete ...
+        // This section will exit after the last build completes.
+        echo "Waiting for builds to complete ..."
+        builds.withEach {
+          // untilEach and watch - do not support watching multiple named resources,
+          // so we have to feed it one at a time.
+          it.untilEach(1) {
+              echo "${it.object().status.phase} - ${it.name()}"
+              return (it.object().status.phase == "Complete")
+          }
+        }
       }
     }
   }
@@ -122,21 +126,14 @@ node {
   // Build base images
   stage("Building base images...") {
     script {
-      openshift.withCluster() {
-        openshift.withProject() {
-          build(config.BASE_IMAGE_SELECTOR);
-      }
+      build(config.BASE_IMAGE_SELECTOR);
     }
   }
 
   // Build runtime images and deploy when ready
   stage("Building runtime images...") {
     script {
-      openshift.withCluster() {
-        openshift.withProject() {
-          build.(config.RUNTIME_IMAGE_SELECTOR);
-        }
-      }
+      build.(config.RUNTIME_IMAGE_SELECTOR);
     }
   }
 

--- a/jenkins/identity-kit/Jenkinsfile
+++ b/jenkins/identity-kit/Jenkinsfile
@@ -44,7 +44,7 @@ String getImageTagHash(OpenShiftDSL openshift, String imageName, String tag = ""
   return istag.out.tokenize('@')[1].trim()
 }
 
-void build(String imageSelector) {
+void build(String imageSelector, Map<String, String> APP_CONTEXT_DIRS, int WAIT_TIMEOUT) {
   openshift.withCluster() {
     openshift.withProject() {
       //  Retrieve all build configurations based on the selector
@@ -54,7 +54,7 @@ void build(String imageSelector) {
       // Set 'run-build' label based on wether there have been changes in the context directory
       buildConfigsAll.withEach {
         def buildName = it.name().split("/")[1];
-        def contextDir = config.APP_CONTEXT_DIRS[buildName];
+        def contextDir = APP_CONTEXT_DIRS[buildName];
         if(triggerBuild(contextDir)){
             setRunBuildLabel(it, 'true');
         }
@@ -73,7 +73,7 @@ void build(String imageSelector) {
           setRunBuildLabel(it, 'false');
       }
 
-      timeout(config.WAIT_TIMEOUT) {
+      timeout(WAIT_TIMEOUT) {
         // Wait for all the builds to complete ...
         // This section will exit after the last build completes.
         echo "Waiting for builds to complete ..."
@@ -126,14 +126,14 @@ node {
   // Build base images
   stage("Building base images...") {
     script {
-      build(config.BASE_IMAGE_SELECTOR);
+      build(config.BASE_IMAGE_SELECTOR, config.APP_CONTEXT_DIRS, config.WAIT_TIMEOUT);
     }
   }
 
   // Build runtime images and deploy when ready
   stage("Building runtime images...") {
     script {
-      build.(config.RUNTIME_IMAGE_SELECTOR);
+      build(config.RUNTIME_IMAGE_SELECTOR, config.APP_CONTEXT_DIRS, config.WAIT_TIMEOUT);
     }
   }
 

--- a/jenkins/identity-kit/Jenkinsfile
+++ b/jenkins/identity-kit/Jenkinsfile
@@ -44,6 +44,48 @@ String getImageTagHash(OpenShiftDSL openshift, String imageName, String tag = ""
   return istag.out.tokenize('@')[1].trim()
 }
 
+void build(String imageSelector) {
+  //  Retrieve all build configurations based on the selector
+  def buildConfigsAll = openshift.selector("bc", [ "app-group" : "${imageSelector}" ])
+  echo "Found ${buildConfigsAll.count()} buildconfigs for app label (app-group=${imageSelector}): ${buildConfigsAll.names()}"
+
+  // Set 'run-build' label based on wether there have been changes in the context directory
+  buildConfigsAll.withEach {
+    def buildName = it.name().split("/")[1];
+    def contextDir = config.APP_CONTEXT_DIRS[buildName];
+    if(triggerBuild(contextDir)){
+        setRunBuildLabel(it, 'true');
+    }
+  }
+
+  // Retrieve all the build configs that need to be executed
+  def buildConfigsRun = openshift.selector("bc", [ "app-group" : "${imageSelector}", "run-build" : "true" ])
+  echo "Found ${buildConfigsRun.count()} buildconfigs for app label (app=${imageSelector}, run-build=true): ${buildConfigsRun.names()}"
+
+  // Kick off all the builds in parallel ...
+  def builds = buildConfigsRun.startBuild()
+  echo "Started ${builds.count()} builds: ${builds.names()}"
+
+  // Reset run-build label now that builds have started
+  buildConfigsRun.withEach {
+      setRunBuildLabel(it, 'false');
+  }
+
+  timeout(config.WAIT_TIMEOUT) {
+    // Wait for all the builds to complete ...
+    // This section will exit after the last build completes.
+    echo "Waiting for builds to complete ..."
+    builds.withEach {
+      // untilEach and watch - do not support watching multiple named resources,
+      // so we have to feed it one at a time.
+      it.untilEach(1) {
+          echo "${it.object().status.phase} - ${it.name()}"
+          return (it.object().status.phase == "Complete")
+      }
+    }
+  }
+}
+
 void deploy(String appName, String namespace, String envTag) {
   openshift.withCluster() {
     openshift.withProject() {
@@ -77,51 +119,12 @@ void setRunBuildLabel(OpenShiftDSL.OpenShiftResourceSelector  bc, String flagVal
 node {
   def config = load "../workspace@script/jenkins/config.groovy"
 
-  // Build base images, if necessary
+  // Build base images
   stage("Building base images...") {
     script {
       openshift.withCluster() {
         openshift.withProject() {
-          //  Retrieve all base image build configurations
-          def baseBuildConfigs = openshift.selector("bc", [ "app-group" : "${config.BASE_IMAGE_SELECTOR}" ])
-          echo "Found ${baseBuildConfigs.count()} buildconfigs for app label (app-group=${config.BASE_IMAGE_SELECTOR}): ${baseBuildConfigs.names()}"
-
-          // Set 'run-build' label based on wether there have been changes in the context directory
-          baseBuildConfigs.withEach {
-            def buildName = it.name().split("/")[1];
-            def contextDir = config.APP_CONTEXT_DIRS[buildName];
-            if(triggerBuild(contextDir)){
-                setRunBuildLabel(it, 'true');
-            }
-          }
-
-          // Retrieve all the base image build configs that need to be executed
-          def buildConfigs = openshift.selector("bc", [ "app-group" : "${config.BASE_IMAGE_SELECTOR}", "run-build" : "true" ])
-          echo "Found ${buildConfigs.count()} buildconfigs for app label (app=${config.BASE_IMAGE_SELECTOR}, run-build=true): ${buildConfigs.names()}"
-
-          // Kick off all the builds in parallel ...
-          def builds = buildConfigs.startBuild()
-          echo "Started ${builds.count()} builds: ${builds.names()}"
-
-          // Reset run-build label now that builds have started
-          buildConfigs.withEach {
-              setRunBuildLabel(it, 'false');
-          }
-
-          timeout(config.WAIT_TIMEOUT) {
-            // Wait for all the builds to complete ...
-            // This section will exit after the last build completes.
-            echo "Waiting for builds to complete ..."
-            builds.withEach {
-              // untilEach and watch - do not support watching multiple named resources,
-              // so we have to feed it one at a time.
-              it.untilEach(1) {
-                  echo "${it.object().status.phase} - ${it.name()}"
-                  return (it.object().status.phase == "Complete")
-              }
-            }
-          }
-        }
+          build(config.BASE_IMAGE_SELECTOR);
       }
     }
   }
@@ -131,44 +134,7 @@ node {
     script {
       openshift.withCluster() {
         openshift.withProject() {
-          //  Retrieve all runtime image build configurations
-          def runtimeBuildConfigs = openshift.selector("bc", [ "app-group" : "${config.RUNTIME_IMAGE_SELECTOR}" ])
-          echo "Found ${runtimeBuildConfigs.count()} buildconfigs for app-group label (app-group=${config.RUNTIME_IMAGE_SELECTOR}): ${runtimeBuildConfigs.names()}"
-
-          runtimeBuildConfigs.withEach {
-            def buildName = it.name().split("/")[1];
-            def contextDir = config.APP_CONTEXT_DIRS[buildName];
-            if(triggerBuild(contextDir)){
-                setRunBuildLabel(it, 'true');
-            }
-          }
-
-          // Retrieve all the runtime image build configs that need to be executed
-          def buildConfigs = openshift.selector("bc", [ "app-group" : "${config.RUNTIME_IMAGE_SELECTOR}", "run-build" : "true" ])
-          echo "Found ${buildConfigs.count()} buildconfigs for app label (app=${config.RUNTIME_IMAGE_SELECTOR}, run-build=true): ${buildConfigs.names()}"
-
-          // Kick off all the builds in parallel ...
-          def builds = buildConfigs.startBuild()
-          echo "Started ${builds.count()} builds: ${builds.names()}"
-
-          // Reset run-build label now that builds have started
-          buildConfigs.withEach {
-              setRunBuildLabel(it, 'false');
-          }
-
-          timeout(config.WAIT_TIMEOUT) {
-            // Wait for all the builds to complete ...
-            // This section will exit after the last build completes.
-            echo "Waiting for builds to complete ..."
-            builds.withEach {
-              // untilEach and watch - do not support watching multiple named resources,
-              // so we have to feed it one at a time.
-              it.untilEach(1) {
-                  echo "${it.object().status.phase} - ${it.name()}"
-                  return (it.object().status.phase == "Complete")
-              }s
-            }
-          }
+          build.(config.RUNTIME_IMAGE_SELECTOR);
         }
       }
     }

--- a/jenkins/identity-kit/Jenkinsfile
+++ b/jenkins/identity-kit/Jenkinsfile
@@ -128,8 +128,8 @@ node {
             def buildName = it.name().split("/")[1];
             def contextDir = config.APP_CONTEXT_DIRS[buildName];
             if(triggerBuild(contextDir)){
-                echo "Building the ${it.name()} image ..."
-                build(openshift, "${it.name()}", config.WAIT_TIMEOUT)
+                echo "Building the ${buildName} image ..."
+                build(openshift, "${buildName}", config.WAIT_TIMEOUT)
             }
           }
         }
@@ -149,8 +149,8 @@ node {
             def buildName = it.name().split("/")[1];
             def contextDir = config.APP_CONTEXT_DIRS[buildName];
             if(triggerBuild(contextDir)){
-                echo "Building the ${it.name()} image ..."
-                build(openshift, "${it.name()}", config.WAIT_TIMEOUT)
+                echo "Building the ${buildName} image ..."
+                build(openshift, "${buildName}", config.WAIT_TIMEOUT)
             }
           }
         }

--- a/jenkins/identity-kit/Jenkinsfile
+++ b/jenkins/identity-kit/Jenkinsfile
@@ -1,28 +1,40 @@
-// The applicatino label
-// This is used to find all of the build configurations associated to the application
-// To work the build configurations must have an "app" label;
-// - For example; app=iiw-book
-def APP_LABEL = 'identity-kit'
+import com.openshift.jenkins.plugins.OpenShiftDSL;
 
-// Wait timeout in minutes
-def WAIT_TIMEOUT = 10
+@NonCPS
+boolean triggerBuild(String contextDirectory) {
+  // Determine if code has changed within the source context directory.
+  def changeLogSets = currentBuild.changeSets
+  def filesChangeCnt = 0
+  for (int i = 0; i < changeLogSets.size(); i++) {
+    def entries = changeLogSets[i].items
+    for (int j = 0; j < entries.length; j++) {
+      def entry = entries[j]
+      //echo "${entry.commitId} by ${entry.author} on ${new Date(entry.timestamp)}: ${entry.msg}"
+      def files = new ArrayList(entry.affectedFiles)
+      for (int k = 0; k < files.size(); k++) {
+        def file = files[k]
+        def filePath = file.path
+        //echo ">> ${file.path}"
+        if (filePath.contains(contextDirectory)) {
+          filesChangeCnt = 1
+          k = files.size()
+          j = entries.length
+        }
+      }
+    }
+  }
 
-// Assumes Builds, Images, and Deployments all have the same name(s)
-// Components will be deployed in the order they are listed.
-def COMPONENTS = ['identity-kit-admin', 'identity-kit-public', 'identity-kit-controller', 'identity-kit-agent', 'identity-kit-db', 'identity-kit-wallet']
+  if ( filesChangeCnt < 1 ) {
+    echo("The changes in ${contextDirectory} do not require a build.")
+    return false
+  }
+  else {
+    echo("The changes in ${contextDirectory} require a build.")
+    return true
+  }
+}
 
-// Edit your environment TAG names below
-def TAG_NAMES = ['prod']
-
-// Edit your deployment environment names below
-def DEP_ENV_NAMES = ['prod']
-
-
-// The base namespace of you environments.
-def NAME_SPACE = 'devex-von'
-
-// Get an image's hash tag
-String getImageTagHash(String imageName, String tag = "") {
+String getImageTagHash(OpenShiftDSL openshift, String imageName, String tag = "") {
 
   if(!tag?.trim()) {
     tag = "latest"
@@ -32,91 +44,125 @@ String getImageTagHash(String imageName, String tag = "") {
   return istag.out.tokenize('@')[1].trim()
 }
 
+void build(OpenShiftDSL openshift, String buildConfigName, int waitTimeout = 10, String contextDirectory = '', String envVars = '') {
+
+  def buildFromDir = ''
+
+  // Find all of the build configurations associated to the application ...
+  echo "Looking up build configurations for ${buildConfigName} ..."
+  def buildconfigs = openshift.selector("bc", "${buildConfigName}")
+  echo "Found ${buildconfigs.count()} buildconfigs: ${buildconfigs.names()}"
+
+  // Inject environment variables into the build as needed ...
+  if (envVars?.trim()) {
+    echo "Setting environment variables on bc/${buildConfigName} ..."
+    echo "envVars: ${envVars}"
+    buildconfigs.set("env bc/${buildConfigName} ${envVars}")
+  }
+
+  // Perform a binary build as needed ...
+  if (contextDirectory?.trim()) {
+    echo "Setting up for binary build using the source in the ${contextDirectory} directory ..."
+    buildFromDir = "--from-dir='${contextDirectory}'"
+    echo "buildFromDir: ${buildFromDir}"
+  }
+
+  // Kick off all the builds in parallel ...
+  def builds = buildconfigs.startBuild("${buildFromDir}")
+  echo "Started ${builds.count()} builds: ${builds.names()}"
+
+  timeout(waitTimeout) {
+    // Wait for all the builds to complete ...
+    // This section will exit after the last build completes.
+    echo "Waiting for builds to complete ..."
+    builds.withEach {
+      // untilEach and watch - do not support watching multiple named resources,
+      // so we have to feed it one at a time.
+      it.untilEach(1) {
+          echo "${it.object().status.phase} - ${it.name()}"
+          return (it.object().status.phase == "Complete")
+      }
+    }
+  }
+
+  echo "Builds complete ..."
+}
+
+void deploy(String appName, String namespace, String envTag) {
+  openshift.withCluster() {
+    openshift.withProject() {
+
+      echo "Tagging ${appName} for deployment to ${envTag} ..."
+
+      // Don't tag with BUILD_ID so the pruner can do it's job; it won't delete tagged images.
+      // Tag the images for deployment based on the image's hash
+      def IMAGE_HASH = getImageTagHash(openshift, "${appName}")
+      echo "IMAGE_HASH: ${IMAGE_HASH}"
+      openshift.tag("${appName}@${IMAGE_HASH}", "${appName}:${envTag}")
+    }
+
+    echo "Watching rollout of ${appName} in ${namespace}-${envTag} ..."
+    openshift.withProject("${namespace}-${envTag}") {
+        def dc = openshift.selector('dc', "${appName}")
+        // Wait for the deployment to complete.
+        // This will wait until the desired replicas are all available
+        dc.rollout().status()
+    }
+
+    echo "Deployment Complete."
+  }
+}
+
 node {
-  stage("Building images ...") {
+  def config = load "../workspace@script/jenkins/config.groovy"
+
+  // Build base images, if necessary
+  stage("Building base images...") {
     script {
       openshift.withCluster() {
         openshift.withProject() {
+          def BASE_IMAGES = openshift.selector("bc", [ "app-group" : "${config.BASE_IMAGE_SELECTOR}" ])
+          echo "Found ${BASE_IMAGES.count()} buildconfigs for app label (app=${config.BASE_IMAGE_SELECTOR}): ${BASE_IMAGES.names()}"
 
-          def BASE_IMAGE_SELECTOR = "${APP_LABEL}-base-image"
-
-          // Find all of the build configurations for the base images, using labels ...
-          def baseImageBuildConfigs = openshift.selector("bc", [ "app-group" : "${BASE_IMAGE_SELECTOR}" ])
-          echo "Found ${baseImageBuildConfigs.count()} buildconfigs for app-group label (app-group=${BASE_IMAGE_SELECTOR}): ${baseImageBuildConfigs.names()}"
-
-          // Kick off all the base image builds in parallel ...
-          def baseImageBuilds = baseImageBuildConfigs.startBuild()
-          echo "Started ${baseImageBuilds.count()} builds: ${baseImageBuilds.names()}"
-
-          timeout(WAIT_TIMEOUT) {
-            // Wait for all the builds to complete ...
-            // This section will exit after the last build completes.
-            echo "Waiting for builds to complete ..."
-            baseImageBuilds.withEach {
-              // untilEach and watch - do not support watching multiple named resources,
-              // so we have to feed it one at a time.
-              it.untilEach(1) {
-                  echo "${it.object().status.phase} - ${it.name()}"
-                  return (it.object().status.phase == "Complete")
-              }
+          BASE_IMAGES.withEach {
+            def buildName = it.name().split("/")[1];
+            def contextDir = config.APP_CONTEXT_DIRS[buildName];
+            if(triggerBuild(contextDir)){
+                echo "Building the ${it.name()} image ..."
+                build(openshift, "${it.name()}", config.WAIT_TIMEOUT)
             }
           }
-
-          def RUNTIME_IMAGE_SELECTOR = "${APP_LABEL}-runtime"
-
-          // Find all of the build configurations for the runtime images, using labels ...
-          def runtimeImageBuildConfigs = openshift.selector("bc", [ "app-group" : "${RUNTIME_IMAGE_SELECTOR}" ])
-          echo "Found ${runtimeImageBuildConfigs.count()} buildconfigs for app-group label (app-group=${RUNTIME_IMAGE_SELECTOR}): ${runtimeImageBuildConfigs.names()}"
-
-          // Kick off all the base image builds in parallel ...
-          def runtimeImageBuilds = runtimeImageBuildConfigs.startBuild()
-          echo "Started ${runtimeImageBuilds.count()} builds: ${runtimeImageBuilds.names()}"
-
-          timeout(WAIT_TIMEOUT) {
-            // Wait for all the builds to complete ...
-            // This section will exit after the last build completes.
-            echo "Waiting for builds to complete ..."
-            runtimeImageBuilds.withEach {
-              // untilEach and watch - do not support watching multiple named resources,
-              // so we have to feed it one at a time.
-              it.untilEach(1) {
-                  echo "${it.object().status.phase} - ${it.name()}"
-                  return (it.object().status.phase == "Complete")
-              }
-            }
-          }
-
-          echo "Builds complete ..."
         }
       }
     }
   }
 
-  for(item in COMPONENTS)
-  {
-    stage("Deploying ${item}") {
-      script {
-        openshift.withCluster() {
-          openshift.withProject() {
+  // Build runtime images and deploy when ready
+  stage("Building runtime images...") {
+    script {
+      openshift.withCluster() {
+        openshift.withProject() {
+          def RUNTIME_IMAGES = openshift.selector("bc", [ "app-group" : "${config.RUNTIME_IMAGE_SELECTOR}" ])
+          echo "Found ${RUNTIME_IMAGES.count()} buildconfigs for app-group label (app-group=${config.RUNTIME_IMAGE_SELECTOR}): ${RUNTIME_IMAGES.names()}"
 
-            echo "Tagging ${item} for deployment to ${TAG_NAMES[0]} ..."
-
-            // Don't tag with BUILD_ID so the pruner can do it's job; it won't delete tagged images.
-            // Tag the images for deployment based on the image's hash
-            def IMAGE_HASH = getImageTagHash("${item}")
-            echo "IMAGE_HASH: ${IMAGE_HASH}"
-            openshift.tag("${item}@${IMAGE_HASH}", "${item}:${TAG_NAMES[0]}")
+          RUNTIME_IMAGES.withEach {
+            def buildName = it.name().split("/")[1];
+            def contextDir = config.APP_CONTEXT_DIRS[buildName];
+            if(triggerBuild(contextDir)){
+                echo "Building the ${it.name()} image ..."
+                build(openshift, "${it.name()}", config.WAIT_TIMEOUT)
+            }
           }
-
-          openshift.withProject("${NAME_SPACE}-${DEP_ENV_NAMES[0]}") {
-              def dc = openshift.selector('dc', "${item}")
-              // Wait for the deployment to complete.
-              // This will wait until the desired replicas are all available
-              dc.rollout().status()
-          }
-
-          echo "Deployment Complete."
         }
+      }
+    }
+  }
+
+  // Deploying new images
+  stage("Deploy images to ${config.PROD_ENV}") {
+    script {
+      config.APPS.each{
+        deploy("${it}", "${config.NAME_SPACE}", "${config.PROD_ENV}")
       }
     }
   }

--- a/jenkins/identity-kit/Jenkinsfile
+++ b/jenkins/identity-kit/Jenkinsfile
@@ -44,50 +44,6 @@ String getImageTagHash(OpenShiftDSL openshift, String imageName, String tag = ""
   return istag.out.tokenize('@')[1].trim()
 }
 
-void build(OpenShiftDSL openshift, String buildConfigName, int waitTimeout = 10, String contextDirectory = '', String envVars = '') {
-
-  def buildFromDir = ''
-
-  // Find all of the build configurations associated to the application ...
-  echo "Looking up build configurations for ${buildConfigName} ..."
-  def buildconfigs = openshift.selector("bc", "${buildConfigName}")
-  echo "Found ${buildconfigs.count()} buildconfigs: ${buildconfigs.names()}"
-
-  // Inject environment variables into the build as needed ...
-  if (envVars?.trim()) {
-    echo "Setting environment variables on bc/${buildConfigName} ..."
-    echo "envVars: ${envVars}"
-    buildconfigs.set("env bc/${buildConfigName} ${envVars}")
-  }
-
-  // Perform a binary build as needed ...
-  if (contextDirectory?.trim()) {
-    echo "Setting up for binary build using the source in the ${contextDirectory} directory ..."
-    buildFromDir = "--from-dir='${contextDirectory}'"
-    echo "buildFromDir: ${buildFromDir}"
-  }
-
-  // Kick off all the builds in parallel ...
-  def builds = buildconfigs.startBuild("${buildFromDir}")
-  echo "Started ${builds.count()} builds: ${builds.names()}"
-
-  timeout(waitTimeout) {
-    // Wait for all the builds to complete ...
-    // This section will exit after the last build completes.
-    echo "Waiting for builds to complete ..."
-    builds.withEach {
-      // untilEach and watch - do not support watching multiple named resources,
-      // so we have to feed it one at a time.
-      it.untilEach(1) {
-          echo "${it.object().status.phase} - ${it.name()}"
-          return (it.object().status.phase == "Complete")
-      }
-    }
-  }
-
-  echo "Builds complete ..."
-}
-
 void deploy(String appName, String namespace, String envTag) {
   openshift.withCluster() {
     openshift.withProject() {
@@ -113,6 +69,11 @@ void deploy(String appName, String namespace, String envTag) {
   }
 }
 
+void setRunBuildLabel(OpenShiftDSL.OpenShiftResourceSelector  bc, String flagValue) {
+  echo "Setting label 'run-build' to '${flagValue}' for ${bc.name()}"
+  bc.label([ 'run-build':"${flagValue}" ], "--overwrite")
+}
+
 node {
   def config = load "../workspace@script/jenkins/config.groovy"
 
@@ -121,15 +82,43 @@ node {
     script {
       openshift.withCluster() {
         openshift.withProject() {
-          def BASE_IMAGES = openshift.selector("bc", [ "app-group" : "${config.BASE_IMAGE_SELECTOR}" ])
-          echo "Found ${BASE_IMAGES.count()} buildconfigs for app label (app=${config.BASE_IMAGE_SELECTOR}): ${BASE_IMAGES.names()}"
+          //  Retrieve all base image build configurations
+          def baseBuildConfigs = openshift.selector("bc", [ "app-group" : "${config.BASE_IMAGE_SELECTOR}" ])
+          echo "Found ${baseBuildConfigs.count()} buildconfigs for app label (app-group=${config.BASE_IMAGE_SELECTOR}): ${baseBuildConfigs.names()}"
 
-          BASE_IMAGES.withEach {
+          // Set 'run-build' label based on wether there have been changes in the context directory
+          baseBuildConfigs.withEach {
             def buildName = it.name().split("/")[1];
             def contextDir = config.APP_CONTEXT_DIRS[buildName];
             if(triggerBuild(contextDir)){
-                echo "Building the ${buildName} image ..."
-                build(openshift, "${buildName}", config.WAIT_TIMEOUT)
+                setRunBuildLabel(it, 'true');
+            }
+          }
+
+          // Retrieve all the base image build configs that need to be executed
+          def buildConfigs = openshift.selector("bc", [ "app-group" : "${config.BASE_IMAGE_SELECTOR}", "run-build" : "true" ])
+          echo "Found ${buildConfigs.count()} buildconfigs for app label (app=${config.BASE_IMAGE_SELECTOR}, run-build=true): ${buildConfigs.names()}"
+
+          // Kick off all the builds in parallel ...
+          def builds = buildConfigs.startBuild()
+          echo "Started ${builds.count()} builds: ${builds.names()}"
+
+          // Reset run-build label now that builds have started
+          buildConfigs.withEach {
+              setRunBuildLabel(it, 'false');
+          }
+
+          timeout(config.WAIT_TIMEOUT) {
+            // Wait for all the builds to complete ...
+            // This section will exit after the last build completes.
+            echo "Waiting for builds to complete ..."
+            builds.withEach {
+              // untilEach and watch - do not support watching multiple named resources,
+              // so we have to feed it one at a time.
+              it.untilEach(1) {
+                  echo "${it.object().status.phase} - ${it.name()}"
+                  return (it.object().status.phase == "Complete")
+              }
             }
           }
         }
@@ -142,15 +131,42 @@ node {
     script {
       openshift.withCluster() {
         openshift.withProject() {
-          def RUNTIME_IMAGES = openshift.selector("bc", [ "app-group" : "${config.RUNTIME_IMAGE_SELECTOR}" ])
-          echo "Found ${RUNTIME_IMAGES.count()} buildconfigs for app-group label (app-group=${config.RUNTIME_IMAGE_SELECTOR}): ${RUNTIME_IMAGES.names()}"
+          //  Retrieve all runtime image build configurations
+          def runtimeBuildConfigs = openshift.selector("bc", [ "app-group" : "${config.RUNTIME_IMAGE_SELECTOR}" ])
+          echo "Found ${runtimeBuildConfigs.count()} buildconfigs for app-group label (app-group=${config.RUNTIME_IMAGE_SELECTOR}): ${runtimeBuildConfigs.names()}"
 
-          RUNTIME_IMAGES.withEach {
+          runtimeBuildConfigs.withEach {
             def buildName = it.name().split("/")[1];
             def contextDir = config.APP_CONTEXT_DIRS[buildName];
             if(triggerBuild(contextDir)){
-                echo "Building the ${buildName} image ..."
-                build(openshift, "${buildName}", config.WAIT_TIMEOUT)
+                setRunBuildLabel(it, 'true');
+            }
+          }
+
+          // Retrieve all the runtime image build configs that need to be executed
+          def buildConfigs = openshift.selector("bc", [ "app-group" : "${config.RUNTIME_IMAGE_SELECTOR}", "run-build" : "true" ])
+          echo "Found ${buildConfigs.count()} buildconfigs for app label (app=${config.RUNTIME_IMAGE_SELECTOR}, run-build=true): ${buildConfigs.names()}"
+
+          // Kick off all the builds in parallel ...
+          def builds = buildConfigs.startBuild()
+          echo "Started ${builds.count()} builds: ${builds.names()}"
+
+          // Reset run-build label now that builds have started
+          buildConfigs.withEach {
+              setRunBuildLabel(it, 'false');
+          }
+
+          timeout(config.WAIT_TIMEOUT) {
+            // Wait for all the builds to complete ...
+            // This section will exit after the last build completes.
+            echo "Waiting for builds to complete ..."
+            builds.withEach {
+              // untilEach and watch - do not support watching multiple named resources,
+              // so we have to feed it one at a time.
+              it.untilEach(1) {
+                  echo "${it.object().status.phase} - ${it.name()}"
+                  return (it.object().status.phase == "Complete")
+              }s
             }
           }
         }

--- a/wa-admin/package-lock.json
+++ b/wa-admin/package-lock.json
@@ -76,6 +76,44 @@
         "webpack-sources": "1.4.3",
         "webpack-subresource-integrity": "1.1.0-rc.6",
         "worker-plugin": "3.2.0"
+      },
+      "dependencies": {
+        "terser-webpack-plugin": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
+          "integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
+          "dev": true,
+          "requires": {
+            "cacache": "^12.0.2",
+            "find-cache-dir": "^2.1.0",
+            "is-wsl": "^1.1.0",
+            "schema-utils": "^1.0.0",
+            "serialize-javascript": "^1.7.0",
+            "source-map": "^0.6.1",
+            "terser": "^4.1.2",
+            "webpack-sources": "^1.4.0",
+            "worker-farm": "^1.7.0"
+          },
+          "dependencies": {
+            "find-cache-dir": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+              "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+              "dev": true,
+              "requires": {
+                "commondir": "^1.0.1",
+                "make-dir": "^2.0.0",
+                "pkg-dir": "^3.0.0"
+              }
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
+          }
+        }
       }
     },
     "@angular-devkit/build-optimizer": {
@@ -11132,16 +11170,16 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
-      "integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
       "dev": true,
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^1.7.0",
+        "serialize-javascript": "^2.1.2",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",
@@ -11158,6 +11196,12 @@
             "make-dir": "^2.0.0",
             "pkg-dir": "^3.0.0"
           }
+        },
+        "serialize-javascript": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+          "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
+          "dev": true
         },
         "source-map": {
           "version": "0.6.1",

--- a/wa-public/package-lock.json
+++ b/wa-public/package-lock.json
@@ -76,6 +76,44 @@
         "webpack-sources": "1.4.3",
         "webpack-subresource-integrity": "1.1.0-rc.6",
         "worker-plugin": "3.2.0"
+      },
+      "dependencies": {
+        "terser-webpack-plugin": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
+          "integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
+          "dev": true,
+          "requires": {
+            "cacache": "^12.0.2",
+            "find-cache-dir": "^2.1.0",
+            "is-wsl": "^1.1.0",
+            "schema-utils": "^1.0.0",
+            "serialize-javascript": "^1.7.0",
+            "source-map": "^0.6.1",
+            "terser": "^4.1.2",
+            "webpack-sources": "^1.4.0",
+            "worker-farm": "^1.7.0"
+          },
+          "dependencies": {
+            "find-cache-dir": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+              "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+              "dev": true,
+              "requires": {
+                "commondir": "^1.0.1",
+                "make-dir": "^2.0.0",
+                "pkg-dir": "^3.0.0"
+              }
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
+          }
+        }
       }
     },
     "@angular-devkit/build-optimizer": {
@@ -10877,16 +10915,16 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
-      "integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
       "dev": true,
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^1.7.0",
+        "serialize-javascript": "^2.1.2",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",
@@ -10903,6 +10941,12 @@
             "make-dir": "^2.0.0",
             "pkg-dir": "^3.0.0"
           }
+        },
+        "serialize-javascript": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+          "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
+          "dev": true
         },
         "source-map": {
           "version": "0.6.1",


### PR DESCRIPTION
The changes use a hybrid approach between the newer style pipeline leveraging configuration files (see #38 for references and examples) and the existing pipelines that could use parallelized execution of builds to cut down on build time.

The Jenkinsfile can definitely still be polished further, however this seems like a good landing point to start using the new pipeline and possibly come back at a later time with improvements.

The `jenkins-client-plugin` objects don't play well when trying to dynamically modify the list of resources returned by a selector (they are not collections), so I resorted to using a custom label that is applied to the relevant build configurations when changes are detected in a context directory. All the build configurations that are flagged with `run-build:true` will then be executed in parallel, and the flag will then be set/reset to `false` to clear them from the build queue the next time the pipeline is started.

I have tested the parallel execution of the base image builds, but haven't yet run through a full pipeline execution that includes also executing the relevant runtime images - however I do not expect any issue with that as it is using logic that has been proven in multiple previous pipeline scenarios.