### PR TITLE
Add fall-back to using user data from invite token

### DIFF
--- a/identity-controller/package-lock.json
+++ b/identity-controller/package-lock.json
@@ -469,9 +469,9 @@
       "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA=="
     },
     "@hapi/hoek": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-      "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
     },
     "@hapi/joi": {
       "version": "16.1.7",

--- a/identity-controller/src/app/admin/invitation/invitation.service.ts
+++ b/identity-controller/src/app/admin/invitation/invitation.service.ts
@@ -5,7 +5,11 @@ export interface IValidateLink {
   _id: string;
   expired: boolean;
   active: boolean;
-  email?: string;
+  user?: {
+    firstName: string;
+    lastName: string;
+    email: string;
+  };
 }
 
 export class InvitationService {
@@ -22,12 +26,16 @@ export class InvitationService {
       query: { linkId },
     });
     if (!res) return { _id: '', active: false, expired: true };
-    if (res.issued) return { _id: res._id, active: true, expired: false, email: res.email }
+    if (res.issued) return { _id: res._id, active: true, expired: false, user: undefined }
     return {
       _id: res._id,
       active: res.active,
       expired: res.expiry.getTime() <= Date.now(),
-      email: res.email
+      user: {
+        firstName: res.firstName,
+        lastName: res.lastName,
+        email: res.email
+      }
     };
   }
 

--- a/wa-public/src/app/components/request-token/request-token.component.ts
+++ b/wa-public/src/app/components/request-token/request-token.component.ts
@@ -66,7 +66,7 @@ export class RequestTokenComponent implements OnInit {
     private loadingCtrl: LoadingController,
     private stateSvc: StateService,
   ) {
-    const email = this.stateSvc.email || '';
+    const email = this.stateSvc.invitedUser.user.email || '';
     const fc = new FormControl(email, [Validators.required, Validators.email]);
     this.fc = fc;
   }

--- a/wa-public/src/app/guards/valid-invite.guard.ts
+++ b/wa-public/src/app/guards/valid-invite.guard.ts
@@ -15,11 +15,7 @@ import { ActionService } from '../services/action.service';
   providedIn: 'root',
 })
 export class ValidInviteGuard implements CanActivate {
-  constructor(
-    private stateService: StateService,
-    private router: Router,
-    private actionSvc: ActionService,
-  ) {}
+  constructor(private stateService: StateService, private router: Router) {}
 
   canActivate(
     route: ActivatedRouteSnapshot,
@@ -32,7 +28,7 @@ export class ValidInviteGuard implements CanActivate {
     const inviteToken = route.queryParamMap.get('invite_token');
 
     return this.stateService.isValidToken(inviteToken).pipe(
-      tap(obs => (this.actionSvc.email = obs.email || '')),
+      tap(obs => (this.stateService.invitedUser = obs.user)),
       map(obs => {
         console.log(obs);
         if (!obs) return false;

--- a/wa-public/src/app/pages/success/success.component.ts
+++ b/wa-public/src/app/pages/success/success.component.ts
@@ -386,11 +386,11 @@ export class SuccessComponent implements OnInit, OnDestroy {
 
     if (!user || user.email.match('@identity-kit.org')) {
       user = {
-        firstName: '',
-        lastName: '',
-        email: ''
+        firstName: this.stateSvc.invitedUser.firstName,
+        lastName: this.stateSvc.invitedUser.lastName,
+        email: this.stateSvc.invitedUser.email
       };
-      this.validAuthenticatedUser = false;
+      this.validAuthenticatedUser = (user.firstName !== '' && user.lastName !== '' && user.email !== '');
     }
 
     const firstName = new FormControl(user.firstName, [Validators.required]);

--- a/wa-public/src/app/pages/success/success.component.ts
+++ b/wa-public/src/app/pages/success/success.component.ts
@@ -384,7 +384,7 @@ export class SuccessComponent implements OnInit, OnDestroy {
     const keys = Object.keys(user);
     this.disableList = keys.filter(key => user[key] !== undefined || null || '');
 
-    if (!user || user.email.match('@identity-kit.org')) {
+    if (!user || user.email || user.email.match('@identity-kit.org')) {
       user = {
         firstName: this.stateSvc.invitedUser.firstName,
         lastName: this.stateSvc.invitedUser.lastName,

--- a/wa-public/src/app/services/action.service.ts
+++ b/wa-public/src/app/services/action.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { KeycloakService } from 'keycloak-angular';
 import { IInvitationRecord } from '../interfaces/invitation-record';
 import { AppConfigService } from './app-config.service';
-import { StateService } from './state.service';
+import { StateService, IValidateLink } from './state.service';
 
 export interface IInvitation {
   connection_id: string;
@@ -96,13 +96,6 @@ export interface KeyCorrectnessProof {
 })
 export class ActionService {
   _apiUrl: string;
-  authenticate() {
-    // TODO: @ES some authentication logic here
-  }
-
-  set email(addr: string) {
-    localStorage.setItem('email', addr);
-  }
 
   constructor(
     private keyCloakSvc: KeycloakService,

--- a/wa-public/src/app/services/state.service.ts
+++ b/wa-public/src/app/services/state.service.ts
@@ -12,7 +12,11 @@ export interface IValidateLink {
   _id: string;
   expired: boolean;
   active: boolean;
-  email?: string;
+  user?: {
+    firstName: string;
+    lastName: string;
+    email: string;
+  };
 }
 
 @Injectable({
@@ -21,6 +25,8 @@ export interface IValidateLink {
 export class StateService {
   private _isAuth = false;
   private _title = 'Identity Kit POC';
+  private _apiUrl: string;
+  user: IUser = {};
 
   get linkId() {
     return localStorage.getItem('linkId');
@@ -34,12 +40,13 @@ export class StateService {
     localStorage.setItem('id', id);
   }
 
-  get email(): string {
-    return localStorage.getItem('email') || '';
+  set invitedUser(user: any) {
+    localStorage.setItem('invitedUser', JSON.stringify(user));
   }
 
-  user: IUser = {};
-  private _apiUrl: string;
+  get invitedUser() {
+    return JSON.parse(localStorage.getItem('invitedUser'));
+  }
 
   isValidToken(token: string): Observable<IValidateLink> {
     const url = `${this._apiUrl}/invitations/${token}/validate`;


### PR DESCRIPTION
This resolves #102 I believe.

When checking for the validity of the invite token, the API will return `firstName`, `lastName` and `email` of the user that was invited: if the IdP is disablet, did not provide user information OR in the special case where we are running in development mode and the hard-coded users should not be used the attributes from the user invite will be used and will NOT be editable (same as if they were provided by the IdP).

This fixes the flow where no IdP is configured, but we still want the invited user to be pre-filled (I will need to work on handling the remaining claims dynamically, for now it only supports name and email).