### PR TITLE
Rate-limit retry requests

### DIFF
--- a/issuer-web/src/models/appConfig.ts
+++ b/issuer-web/src/models/appConfig.ts
@@ -25,5 +25,5 @@ export interface AppConfig {
 
 export class Configuration {
   public app!: AppConfig;
-  public claims!: any;
+  public claims!: any; //eslint-disable-line @typescript-eslint/no-explicit-any
 }

--- a/issuer-web/src/store/modules/configuration/mutations.ts
+++ b/issuer-web/src/store/modules/configuration/mutations.ts
@@ -10,6 +10,7 @@ export const mutations: MutationTree<ConfigurationState> = {
     state.statusMessage = "success";
     state.stateType = StateType.INITIALIZED;
   },
+  //eslint-disable-next-line @typescript-eslint/no-explicit-any
   setClaimConfig(state: ConfigurationState, claims: any) {
     Vue.set(state.configuration, "claims", claims);
     state.error = false;

--- a/issuer-web/src/utils/index.ts
+++ b/issuer-web/src/utils/index.ts
@@ -1,0 +1,3 @@
+export function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/issuer-web/src/views/Connect.vue
+++ b/issuer-web/src/views/Connect.vue
@@ -83,7 +83,7 @@ export default class Connect extends Vue {
   updated() {
     this.$store
       .dispatch("connection/waitForConnectionStatus", {
-        status: ConnectionStatus.ACTIVE,
+        status: [ConnectionStatus.RESPONSE, ConnectionStatus.ACTIVE],
         cancelToken: this.cancelTokenSource.token
       })
       .then(() => {

--- a/issuer-web/src/views/IssueCredential.vue
+++ b/issuer-web/src/views/IssueCredential.vue
@@ -70,6 +70,7 @@ import Axios, { CancelTokenSource } from "axios";
 import { Connection } from "../models/connection";
 import { Credential } from "../models/credential";
 import { AppConfig, Configuration } from "../models/appConfig";
+import { sleep } from "../utils";
 
 @Component
 export default class Connect extends Vue {
@@ -103,11 +104,12 @@ export default class Connect extends Vue {
 
   async handleIssueCredential(credExId: string, config: AppConfig) {
     const retryInterceptor = Axios.interceptors.response.use(
-      response => {
+      async response => {
         if (response.data.issued) {
           return response;
         } else {
-          // retry until the credential has not been issued
+          // retry every 500ms until the credential has not been issued
+          await sleep(500);
           return Axios.request(response.config);
         }
       },


### PR DESCRIPTION
Rate-limit retry requests, add RESPONSE as valid status to initiate credential issuance.

Signed-off-by: Emiliano Suñé <emiliano.sune@gmail.com>